### PR TITLE
Add showKeyboardWhenReturnSearchResult property

### DIFF
--- a/PYSearch/PYSearchViewController.h
+++ b/PYSearch/PYSearchViewController.h
@@ -395,6 +395,11 @@ didSelectSearchSuggestionAtIndex:(NSInteger)index
 @property (nonatomic, assign) BOOL showSearchResultWhenSearchBarRefocused;
 
 /**
+ Whether show keyboard when return to search result, default is YES.
+ */
+@property (nonatomic, assign) BOOL showKeyboardWhenReturnSearchResult;
+
+/**
  Creates an instance of searchViewContoller with popular searches and search bar's placeholder.
 
  @param hotSearches     popular searchs

--- a/PYSearch/PYSearchViewController.m
+++ b/PYSearch/PYSearchViewController.m
@@ -168,8 +168,11 @@
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
-    
-    [self.searchBar becomeFirstResponder];
+    if (NULL == self.searchResultController.parentViewController) {
+        [self.searchBar becomeFirstResponder];
+    } else if (YES == self.showKeyboardWhenReturnSearchResult) {
+        [self.searchBar becomeFirstResponder];
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -391,6 +394,7 @@
     self.showHotSearch = YES;
     self.showSearchResultWhenSearchTextChanged = NO;
     self.showSearchResultWhenSearchBarRefocused = NO;
+    self.showKeyboardWhenReturnSearchResult = YES;
     self.removeSpaceOnSearchString = YES;
     
     UIView *titleView = [[UIView alloc] init];

--- a/PYSearchExample/PYSearchExample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/PYSearchExample/PYSearchExample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Sometimes it's useful to keep searchbar from becoming `firstResponder` when a user returns to the search result list from any detail view, so that he could switch between different result items without being interfered by keyboard animation.