### PR TITLE
修改iOS11 以modal模式进入页面的约束报错，以及约束报错导致的搜索栏会出现一个从左至右的闪动

### DIFF
--- a/PYSearch/PYSearchViewController.m
+++ b/PYSearch/PYSearchViewController.m
@@ -168,10 +168,11 @@
     // More details : https://github.com/iphone5solo/PYSearch/issues/108
     if (@available(iOS 11.0, *)) { // iOS 11
         if (self.searchViewControllerShowMode == PYSearchViewControllerShowModeModal) {
+            NSLayoutConstraint *leftLayoutConstraint = [searchBar.leftAnchor constraintEqualToAnchor:titleView.leftAnchor];
             if (navigationBarLayoutMargins.left > PYSEARCH_MARGIN) {
-                searchBar.py_x = 0;
+                [leftLayoutConstraint setConstant:0];
             } else {
-                searchBar.py_x = PYSEARCH_MARGIN - navigationBarLayoutMargins.left;
+                [leftLayoutConstraint setConstant:PYSEARCH_MARGIN - navigationBarLayoutMargins.left];
             }
         }
         searchBar.py_height = self.view.py_width > self.view.py_height ? 24 : 30;
@@ -1014,6 +1015,7 @@
 {
     _searchViewControllerShowMode = searchViewControllerShowMode;
     if (_searchViewControllerShowMode == PYSearchViewControllerShowModeModal) { // modal
+        self.navigationItem.hidesBackButton = YES;
         self.navigationItem.rightBarButtonItem = _cancelBarButtonItem;
         self.navigationItem.leftBarButtonItem = nil;
     } else if (_searchViewControllerShowMode == PYSearchViewControllerShowModePush) { // push


### PR DESCRIPTION
### Reference Issue
<!-- Example: Fixes #1234 -->
* 修改iOS11 以modal模式进入页面的约束报错，以及约束报错导致的搜索栏会出现一个从左至右的闪动
* 修复在默认的modal模式下，如果push进去之后，取消按钮变成 ... , 右侧 取消 两字不能正常显示